### PR TITLE
Symmetry

### DIFF
--- a/src/generator_script.jl
+++ b/src/generator_script.jl
@@ -7,10 +7,10 @@ const all_funcs = (
     :sind, :tand, :acosd, :acotd, :acscd, :asecd, :asind, :atand, :rad2deg,
     :deg2rad, :log, :log2, :log10, :log1p, :exponent, :exp, :exp2, :expm1,
     :cbrt, :sqrt, :ceil, :floor, :trunc, :round, :significand, :lgamma, :gamma,
-    :lfact, :frexp, :modf, :airy, :airyprime, :real, :imag, :!, :identity,
+    :lfact, :frexp, :ldexp, :modf, :airy, :airyprime, :real, :imag, :!, :identity,
     :zero, :one, :<<, :>>, :abs2, :sign, :atan2, :sinpi, :cospi, :exp10,
     :iseven, :ispow2, :isfinite, :isinf, :isodd, :isinteger, :isreal, :isimag,
-    :isnan, :isempty, :iszero, :transpose, :ctranspose, :copysign, :signbit,
+    :isnan, :isempty, :iszero, :transpose, :ctranspose, :copysign, :flipsign, :signbit,
     :+, :-, :*, :/, :\, :^, :(==), :(!=), :<, :(<=), :>, :(>=), :≈, :min, :max,
     :div, :fld, :rem, :mod, :mod1, :cmp, :beta, :lbeta, :&, :|, :xor,
     :clamp

--- a/src/overloads.jl
+++ b/src/overloads.jl
@@ -399,7 +399,17 @@ function Base.:lfact(arg1::AbstractNumber)
 end
 
 function Base.:frexp(arg1::AbstractNumber)
-    tmp = Base.:frexp(number(arg1))
+    tmp1, tmp2 = Base.:frexp(number(arg1))
+    like(arg1, tmp1), tmp
+end
+
+function Base.:ldexp(arg1::AbstractNumber, arg2::AbstractNumber)
+    tmp = Base.:ldexp(number(arg1), number(arg2))
+    like(arg1, tmp)
+end
+
+function Base.:ldexp(arg1::AbstractNumber, arg2::Number)
+    tmp = Base.:ldexp(number(arg1), arg2)
     like(arg1, tmp)
 end
 
@@ -610,6 +620,21 @@ end
 
 function Base.:copysign(a::Number, b::AbstractNumber)
     tmp = Base.:copysign(a, number(b))
+    like(b, tmp)
+end
+
+function Base.:flipsign(arg1::AbstractNumber, arg2::AbstractNumber)
+    tmp = Base.:flipsign(number(arg1), number(arg2))
+    like(arg1, tmp)
+end
+
+function Base.:flipsign(a::AbstractNumber, b::Number)
+    tmp = Base.:flipsign(number(a), b)
+    like(a, tmp)
+end
+
+function Base.:flipsign(a::Number, b::AbstractNumber)
+    tmp = Base.:flipsign(a, number(b))
     like(b, tmp)
 end
 
@@ -1422,4 +1447,5 @@ function SpecialFunctions.:zeta(a::Number, b::AbstractNumber)
     tmp = SpecialFunctions.:zeta(a, number(b))
     like(b, tmp)
 end
+
 

--- a/src/overloads.jl
+++ b/src/overloads.jl
@@ -400,7 +400,7 @@ end
 
 function Base.:frexp(arg1::AbstractNumber)
     tmp1, tmp2 = Base.:frexp(number(arg1))
-    like(arg1, tmp1), tmp
+    like(arg1, tmp1) # should return two values
 end
 
 function Base.:ldexp(arg1::AbstractNumber, arg2::AbstractNumber)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,10 +15,10 @@ const all_funcs = (
     :sind, :tand, :acosd, :acotd, :acscd, :asecd, :asind, :atand, :rad2deg,
     :deg2rad, :log, :log2, :log10, :log1p, :exponent, :exp, :exp2, :expm1,
     :cbrt, :sqrt, :ceil, :floor, :trunc, :round, :significand, :lgamma, :gamma,
-    :lfact, :frexp, :modf, :real, :imag, :!, :identity,
+    :lfact, :frexp, :ldexp, :modf, :real, :imag, :!, :identity,
     :zero, :one, :<<, :>>, :abs2, :sign, :atan2, :sinpi, :cospi, :exp10,
     :iseven, :ispow2, :isfinite, :isinf, :isodd, :isinteger, :isreal, :isimag,
-    :isnan, :isempty, :iszero, :transpose, :ctranspose, :copysign, :signbit,
+    :isnan, :isempty, :iszero, :transpose, :ctranspose, :copysign, :flipsign, :signbit,
     :+, :-, :*, :/, :\, :^, :(==), :(!=), :<, :(<=), :>, :(>=), :≈, :min, :max,
     :div, :fld, :rem, :mod, :mod1, :cmp, :beta, :lbeta, :&, :|, :xor,
     :clamp


### PR DESCRIPTION
incorporates `ldexp` and `flipsign`
modifies `frexp` to match its definition, returning two values