### PR TITLE
Aqua

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,11 +6,12 @@ version = "0.2.1"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-julia = "1"
 SpecialFunctions = "0.10, 0.9, 0.8"
+julia = "1"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Aqua", "Test"]

--- a/src/AbstractNumbers.jl
+++ b/src/AbstractNumbers.jl
@@ -15,7 +15,7 @@ abstract type AbstractNumber{T} <: Number end
     AN(T(number(x)))
 end
 
-@inline function Base.convert(::Type{AN}, x::Number) where AN <: AbstractNumber
+@inline function Base.convert(::Type{AN}, x::Number) where AN <: AbstractNumber{T} where T
     AN(x)
 end
 @inline function Base.convert(::Type{T}, x::AbstractNumber) where T <: Number
@@ -29,6 +29,7 @@ end
 
 """
     like(num::AbstractNumber, x::T)
+
 Creates a number from `x` like the first argument. It discards the eltype of `num`
 and uses the type of `x` instead.
 usage:
@@ -54,6 +55,14 @@ usage:
 include("overloads.jl")
 
 rem(x::AbstractNumber, y::AbstractNumber, r::RoundingMode) = like(x, rem(number(x), number(y), r))
+
+
+# Overload ambiguities
+Base.:^(a::Irrational{:ℯ}, b::AbstractNumber) = like(a, Base.:^(a, number(b)))
+Base.:^(a::AbstractNumber, b::Rational) = like(a, Base.:^(number(a), b))
+Base.:^(a::AbstractNumber, b::Integer) = like(a, Base.:^(number(a), b))
+Base.log(a::Irrational{:ℯ}, b::AbstractNumber) = like(a, Base.:^(a, number(b)))
+
 
 export AbstractNumber
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,7 +32,7 @@ all_funcs = (
     :zero, :one, :<<, :>>, :abs2, :sign, :sinpi, :cospi, :exp10,
     :iseven, :ispow2, :isfinite, :isinf, :isodd, :isinteger, :isreal,
     :isnan, :isempty, :iszero, :transpose, :copysign, :flipsign, :signbit,
-    :+, :-, :*, :/, :\, :^, :(==), :(!=), :<, :(<=), :>, :(>=), :≈, :min, :max,
+    :+, :-, :*, :/, :\, :^, :(==), :(!=), :<, :(<=), :>, :(>=), :min, :max,
     :div, :fld, :rem, :mod, :mod1, :cmp, :&, :|, :xor,
     :clamp
 )
@@ -93,8 +93,8 @@ end
 myrand(::Type{T}) where T <: Unsigned = rand(T(1):T(20))
 myrand(::Type{T}) where T = rand(T)
 @testset "AbstractNumbers" begin
-
     for (mod, funcs) in ((Base, all_funcs),), f in funcs
+        println(f)
         func = getfield(mod, f)
         @testset "testing $f" begin
             for i = 1:4
@@ -107,12 +107,12 @@ myrand(::Type{T}) where T = rand(T)
                         (func in (
                             cotd, cosd, cscd, secd, sind, tand, acosd, acotd, acscd,
                             asecd, asind, atand, rem, modf, (<), (>), (<=), (>=),
-                            min, max, cmp, &, |, xor, clamp
+                            min, max, cmp, &, |, xor, clamp, div, fld
                         )) && continue
                     end
                     if T <: AbstractFloat
                         (func in (
-                            &, |, xor,
+                            &, |, xor
                         )) && continue
                     end
                     # i have no idea what these functions are - seem to throw exceptions when not careful with input values
@@ -133,6 +133,14 @@ myrand(::Type{T}) where T = rand(T)
         end
     end
 
+    # isapprox
+    for T in (Float32, Float64, ComplexF64, Int, UInt)
+        T = Float64
+        args = ntuple(x-> myrand(T), 2)
+        a = ≈(args...)
+        b = ≈(MyNumber.(args)...)
+        a == b
+    end
 
 
     @testset "bessel functions" begin
@@ -152,4 +160,7 @@ myrand(::Type{T}) where T = rand(T)
             @test_throws MethodError SF.besseljx(MyNumber(1), MyNumber(complex(big(1.0))))
         end
     end
+
 end
+
+nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,14 @@
 using AbstractNumbers, SpecialFunctions
-using Test
+using Test, Aqua
+
+Aqua.test_ambiguities([AbstractNumbers, Base, Core])
+Aqua.test_unbound_args(AbstractNumbers)
+Aqua.test_undefined_exports(AbstractNumbers)
+Aqua.test_project_extras(AbstractNumbers)
+Aqua.test_stale_deps(AbstractNumbers)
+Aqua.test_deps_compat(AbstractNumbers)
+Aqua.test_project_toml_formatting(AbstractNumbers)
+
 
 struct MyNumber{T} <: AbstractNumbers.AbstractNumber{T}
     number::T


### PR DESCRIPTION
Added Aqua.jl for testing to catch any ambiguities or inconsistencies, and cleaned up a few things it found. Also fixed test issues with `div` and `≈`.